### PR TITLE
generalized `hmf_cache` parameter to let user supply dndm directly

### DIFF
--- a/ares/physics/HaloMassFunction.py
+++ b/ares/physics/HaloMassFunction.py
@@ -375,7 +375,7 @@ class HaloMassFunction(object):
             m = self.tab_M[np.logical_not(np.isnan(self.tab_M))]
             dndm = self.tab_dndm[i][np.logical_not(np.isnan(self.tab_dndm[i]))]
             dndlnm = m * dndm
-            if m[-1] < m[0] * 10 ** 20 / m[3]:
+            if m[-1] < m[0] * 10 ** 18 / m[3]:
                 m_upper = np.arange(np.log(m[-1]), np.log(10 ** 18), np.log(m[1]) - np.log(m[0]))
                 mf_func = InterpolatedUnivariateSpline(np.log(m), np.log(dndlnm), k=1)
                 mf = mf_func(m_upper)

--- a/ares/physics/HaloMassFunction.py
+++ b/ares/physics/HaloMassFunction.py
@@ -366,6 +366,34 @@ class HaloMassFunction(object):
             self._tab_MAR = 10**(np.diff(log_tmar, axis=0).squeeze() \
                 * (m_X - m_X_l) + log_tmar[0])
 
+    def _get_ngtm_mgtm_from_dndm(self):
+
+        # Generates ngtm and mgtm with Murray's formulas
+        ngtm = []
+        mgtm = []
+        for i in range(len(self.tab_z)):
+            m = self.tab_M[np.logical_not(np.isnan(self.tab_M))]
+            dndm = self.tab_dndm[i][np.logical_not(np.isnan(self.tab_dndm[i]))]
+            dndlnm = m * dndm
+            if m[-1] < m[0] * 10 ** 20 / m[3]:
+                m_upper = np.arange(np.log(m[-1]), np.log(10 ** 18), np.log(m[1]) - np.log(m[0]))
+                mf_func = InterpolatedUnivariateSpline(np.log(m), np.log(dndlnm), k=1)
+                mf = mf_func(m_upper)
+
+                int_upper_n = simps(np.exp(mf), dx=m_upper[2] - m_upper[1], even='first')
+                int_upper_m = simps(np.exp(m_upper + mf), dx=m_upper[2] - m_upper[1], even='first')
+            else:
+                int_upper_n = 0
+                int_upper_m = 0
+
+            ngtm_ = np.concatenate((cumtrapz(dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
+            mgtm_ = np.concatenate((cumtrapz(m[::-1] * dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
+
+            ngtm.append(ngtm_ + int_upper_n)
+            mgtm.append(mgtm_ + int_upper_m)
+
+        return np.array(ngtm), np.array(mgtm)
+
     def _load_hmf(self):
         """ Load table from HDF5 or binary. """
 
@@ -376,9 +404,15 @@ class HaloMassFunction(object):
             return self._load_hmf_wdm()
 
         if self.pf['hmf_cache'] is not None:
-            self.tab_z, self.tab_M, self.tab_dndm, self.tab_mgtm, \
-                self.tab_ngtm, self._tab_MAR, self.tab_Mmin_floor = \
-                    self.pf['hmf_cache']
+            if len(self.pf['hmf_cache']) == 3:
+                self.tab_z, self.tab_M, self.tab_dndm = self.pf['hmf_cache']
+                self.tab_ngtm, self.tab_mgtm = self._get_ngtm_mgtm_from_dndm()
+                # tab_MAR will be re-generated automatically if summoned,
+                # as will tab_Mmin_floor.
+            else:
+                self.tab_z, self.tab_M, self.tab_dndm, self.tab_mgtm, \
+                    self.tab_ngtm, self._tab_MAR, self.tab_Mmin_floor = \
+                        self.pf['hmf_cache']
             return
 
         if self.pf['hmf_pca'] is not None:
@@ -391,31 +425,8 @@ class HaloMassFunction(object):
                 tab_dndm_pca += self.pf['hmf_pca_coef{}'.format(i)] * np.array(f[('e_vec')])[i]
 
             self.tab_dndm = 10**np.array(tab_dndm_pca)
-            ngtm, mgtm = [], []
 
-            # Generates ngtm and mgtm with Murray's formulas
-            for i in range(len(self.tab_z)):
-                m = self.tab_M[np.logical_not(np.isnan(self.tab_M))]
-                dndm = self.tab_dndm[i][np.logical_not(np.isnan(self.tab_dndm[i]))]
-                dndlnm = m * dndm
-                if m[-1] < m[0] * 10 ** 20 / m[3]:
-                    m_upper = np.arange(np.log(m[-1]), np.log(10 ** 18), np.log(m[1]) - np.log(m[0]))
-                    mf_func = InterpolatedUnivariateSpline(np.log(m), np.log(dndlnm), k=1)
-                    mf = mf_func(m_upper)
-
-                    int_upper_n = simps(np.exp(mf), dx=m_upper[2] - m_upper[1], even='first')
-                    int_upper_m = simps(np.exp(m_upper + mf), dx=m_upper[2] - m_upper[1], even='first')
-                else:
-                    int_upper_n = 0
-                    int_upper_m = 0
-
-                ngtm_ = np.concatenate((cumtrapz(dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
-                mgtm_ = np.concatenate((cumtrapz(m[::-1] * dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
-
-                ngtm.append(ngtm_ + int_upper_n)
-                mgtm.append(mgtm_ + int_upper_m)
-
-            self.tab_ngtm, self.tab_mgtm = np.array(ngtm), np.array(mgtm)
+            self.tab_ngtm, self.tab_mgtm = self._get_ngtm_mgtm_from_dndm()
 
             f.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ pytest==3.6.4
 pytest-cov==2.8.1
 pyyaml==5.4
 emcee==2.2.1
+docutils<0.18
 -e git+https://bitbucket.org/ktausch/distpy/#egg=distpy

--- a/tests/test_physics_halo_mf.py
+++ b/tests/test_physics_halo_mf.py
@@ -6,7 +6,7 @@ Author: Jordan Mirocha
 Affiliation: McGill
 Created on: Wed 25 Mar 2020 11:15:35 EDT
 
-Description: 
+Description:
 
 """
 
@@ -14,10 +14,25 @@ import ares
 import numpy as np
 import matplotlib.pyplot as pl
 
-def tests():
+def test():
     pop = ares.populations.HaloPopulation()
+
+    m = pop.halos.tab_M
+    iz = np.argmin(np.abs(6 - pop.halos.tab_z))
+    iM = np.argmin(np.abs(1e8 - pop.halos.tab_M))
+
+    dndm = pop.halos.tab_dndm[iz,:]
     
+    fcoll8 = pop.halos.tab_fcoll[iz,iM]
+
+    # Test caching (motivated by PR #24)
+    cache = pop.halos.tab_z, pop.halos.tab_M, pop.halos.tab_dndm
+
+    pop2 = ares.populations.HaloPopulation(hmf_cache=cache)
+    fcoll8_2 = pop2.halos.tab_fcoll[iz,iM]
+
+    assert abs(fcoll8 - fcoll8_2) < 1e-8, \
+        "Error in fcoll auto-generation: {:.12f} {:.12f}".format(fcoll8, fcoll8_2)
+
 if __name__ == '__main__':
-    test()    
-
-
+    test()


### PR DESCRIPTION
moved auto-calculation of ngtm and mgtm from dndm to its own function, allows user to supply `hmf_cache` as 3-element tuple containing (z, Mh, dndm), everything else will be generated automatically