### PR TITLE
Added ares.data to setup packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,4 @@ Additional contributions / corrections / suggestions from:
 - Venno Vipp
 - Oscar Hernandez
 - Joshua Hibbard
+- Trey Driskell

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='ares',
       author='Jordan Mirocha',
       author_email='mirochaj@gmail.com',
       url='https://github.com/mirochaj/ares',
-      packages=['ares', 'ares.analysis', 'ares.simulations', 'ares.obs',
+      packages=['ares', 'ares.analysis', 'ares.data', 'ares.simulations', 'ares.obs',
        'ares.populations', 'ares.util', 'ares.solvers', 'ares.static',
        'ares.sources', 'ares.physics', 'ares.inference', 'ares.phenom'],
      )


### PR DESCRIPTION
Fixes issue on some setups where the ares.data trick to retrieve the path to ares/input causes a ModuleNotFound error. Thanks to Trey Driskell for the fix!