### PR TITLE
updated the values of functions such as zeta, psi, etc.

### DIFF
--- a/ares/static/ChemicalNetwork.py
+++ b/ares/static/ChemicalNetwork.py
@@ -201,7 +201,7 @@ class ChemicalNetwork(object):
         heat = 0.0
         cool = 0.0
         if not self.isothermal:
-
+            self.Beta, self.alpha, self.zeta, self.eta, self.psi, self.xi, self.omega = self.SourceIndependentCoefficients(q[-1], z).values()
             for i, sp in enumerate(self.neutrals):
                 elem = self.grid.parents_by_ion[sp]
 


### PR DESCRIPTION
Since the temperature q[-1] keeps changing, ChemicalNetwork.py needs to update the values of functions zeta, psi, etc., otherwise the subsequent calculation will always call these functions with the original value of q[-1], which will potentially lead to negative temperature q[-1].