### PR TITLE
Adding OSError Handling to camb Imports

### DIFF
--- a/ares/physics/HaloMassFunction.py
+++ b/ares/physics/HaloMassFunction.py
@@ -74,7 +74,7 @@ if have_hmf:
 try:
     import camb
     have_pycamb = True
-except ImportError:
+except (ImportError, OSError):
     have_pycamb = False
 
     try:

--- a/ares/physics/InitialConditions.py
+++ b/ares/physics/InitialConditions.py
@@ -20,7 +20,7 @@ from ..data import ARES
 try:
     import camb
     have_camb = True
-except ImportError:
+except (ImportError, OSError):
     have_camb = False
 
 _pars_CosmoRec = ['cosmorec_nz', 'cosmorec_z0', 'cosmorec_zf',


### PR DESCRIPTION
Changed ares/physics/HaloMassFunction.py and ares/physics/InitialConditions.py and their imports of camb to except OSErrors as well.