### PR TITLE
Change the name of SciPy integration functions

### DIFF
--- a/ares/analysis/MetaGalacticBackground.py
+++ b/ares/analysis/MetaGalacticBackground.py
@@ -11,7 +11,7 @@ Description:
 """
 import matplotlib.pyplot as pl
 import numpy as np
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 
 from ..util import labels
 from ..util.Pickling import read_pickle_file
@@ -268,7 +268,7 @@ class MetaGalacticBackground(object):
         E = np.logspace(np.log10(Emin), np.log10(Emax), Nbins)
         F = self.ResolvedFlux(E, perturb=perturb) / E
 
-        return trapz(F, E)  # erg / s / cm^2 / deg^2
+        return trapezoid(F, E)  # erg / s / cm^2 / deg^2
 
     def PlotIntegratedFlux(self, E, **kwargs):
         return self.PlotSpectrum(E, vs_redshift=True, **kwargs)

--- a/ares/analysis/MultiPhaseMedium.py
+++ b/ares/analysis/MultiPhaseMedium.py
@@ -17,7 +17,7 @@ from ..util.Stats import get_nu
 from ..util.Pickling import read_pickle_file
 from scipy.misc import derivative
 from ..physics.Constants import *
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.interpolate import interp1d
 from ..physics import Cosmology, Hydrogen
 from ..util.SetDefaultParameterValues import *
@@ -335,7 +335,7 @@ class MultiPhaseMedium(object):
 
         integrand *= sigma_T * dldz
 
-        tau = cumtrapz(integrand, self.history_asc['z'], initial=0)
+        tau = cumulative_trapezoid(integrand, self.history_asc['z'], initial=0)
 
         tau[self.history_asc['z'] > 100] = 0.0
 
@@ -797,7 +797,7 @@ class MultiPhaseMedium(object):
 
         integrand *= sigma_T * dldz
 
-        tau = cumtrapz(integrand, ztmp, initial=0)
+        tau = cumulative_trapezoid(integrand, ztmp, initial=0)
 
         return ztmp, tau
 

--- a/ares/core/FluctuationsRealSpace.py
+++ b/ares/core/FluctuationsRealSpace.py
@@ -19,7 +19,7 @@ from scipy.special import erfinv
 from scipy.optimize import fsolve
 from ..physics import ExcursionSet
 from scipy.interpolate import interp1d
-from scipy.integrate import quad, simps
+from scipy.integrate import quad, simpson
 from ..physics.Hydrogen import Hydrogen
 from ..physics.HaloModel import HaloModel
 from ..util.Math import central_difference
@@ -474,8 +474,8 @@ class FluctuationsRealSpace(object): # pragma: no cover
 
         return 1.0
 
-        #return simps(M_h * dndm_h * bias, x=np.log(M_h)) \
-        #    / simps(M_h * dndm_h, x=np.log(M_h))
+        #return simpson(M_h * dndm_h * bias, x=np.log(M_h)) \
+        #    / simpson(M_h * dndm_h, x=np.log(M_h))
 
     def tab_bubble_bias(self, zeta):
         if not hasattr(self, '_tab_bubble_bias'):
@@ -535,7 +535,7 @@ class FluctuationsRealSpace(object): # pragma: no cover
     #
     #    dm_ddel = rho0 * V_i
     #
-    #    return simps(B[iM:] * dndm_b[iM:] * M_b[iM:], x=np.log(M_b[iM:]))
+    #    return simpson(B[iM:] * dndm_b[iM:] * M_b[iM:], x=np.log(M_b[iM:]))
 
     def delta_bubble_vol_weighted(self, z, zeta):
         if not self.pf['ps_include_ion']:
@@ -571,7 +571,7 @@ class FluctuationsRealSpace(object): # pragma: no cover
    #
    #    dm_ddel = rho0 * V_i
    #
-   #    return simps(B[iM:] * dndm_b[iM:] * M_b[iM:], x=np.log(M_b[iM:]))
+   #    return simpson(B[iM:] * dndm_b[iM:] * M_b[iM:], x=np.log(M_b[iM:]))
 
     def mean_halo_abundance(self, z, Mmin=False):
         M_h = self.halos.tab_M
@@ -1919,7 +1919,7 @@ class FluctuationsRealSpace(object): # pragma: no cover
                     #Vii = all_V[0]
                     #_integrand1 = dndm * Vii
                     #
-                    #_exp_int1 = np.exp(-simps(_integrand1[iM:] * M_b[iM:],
+                    #_exp_int1 = np.exp(-simpson(_integrand1[iM:] * M_b[iM:],
                     #    x=np.log(M_b[iM:])))
                     #_P1_ii = (1. - _exp_int1)
 

--- a/ares/core/IntegralTables.py
+++ b/ares/core/IntegralTables.py
@@ -17,7 +17,7 @@ from ..util.ProgressBar import ProgressBar
 from ..physics.Constants import erg_per_ev
 from ..physics.SecondaryElectrons import *
 import os, re, scipy, itertools, math, copy
-from scipy.integrate import quad, trapz, simps
+from scipy.integrate import quad, simpson
 
 try:
     from mpi4py import MPI
@@ -701,7 +701,7 @@ class IntegralTable(object):
             c &= self.E <= self.src.Emax
             samples = np.array([integrand(E) for E in self.E[c]])[..., 0]
 
-            integral = simps(samples, self.E[c]) / erg_per_ev
+            integral = simpson(samples, self.E[c]) / erg_per_ev
 
         if not self.pf['photon_conserving']:
             integral *= self.E_th[absorber]
@@ -738,7 +738,7 @@ class IntegralTable(object):
             c &= self.E <= self.src.Emax
             samples = np.array([integrand(E) for E in self.E[c]])[..., 0]
 
-            integral = simps(samples, self.E[c])
+            integral = simpson(samples, self.E[c])
 
         if not self.pf['photon_conserving']:
             integral *= self.E_th[absorber]
@@ -776,7 +776,7 @@ class IntegralTable(object):
             c &= self.E <= self.src.Emax
             samples = np.array([integrand(E) for E in self.E[c]])[..., 0]
 
-            integral = simps(samples, self.E[c]) / erg_per_ev
+            integral = simpson(samples, self.E[c]) / erg_per_ev
 
         if not self.pf['photon_conserving']:
             integral *= self.E_th[absorber]
@@ -811,7 +811,7 @@ class IntegralTable(object):
             c &= self.E <= self.src.Emax
             samples = np.array([integrand(E) for E in self.E[c]])[..., 0]
 
-            integral = simps(samples, self.E[c])
+            integral = simpson(samples, self.E[c])
 
         if not self.pf['photon_conserving']:
             integral *= self.E_th[absorber]

--- a/ares/core/VolumeGlobal.py
+++ b/ares/core/VolumeGlobal.py
@@ -16,7 +16,7 @@ from ..util import ProgressBar
 from ..physics.Constants import *
 import types, os, re, sys
 from ..physics import SecondaryElectrons
-from scipy.integrate import dblquad, romb, simps, quad, trapz
+from scipy.integrate import dblquad, romb, simpson, quad
 
 try:
     import h5py
@@ -528,7 +528,7 @@ class GlobalVolume(object):
                     heat = romb(integrand[0:imax] * self.E[0:imax],
                         dx=self.dlogE[0:imax])[0] * log10
                 else:
-                    heat = simps(integrand[0:imax] * self._E[popid][band][0:imax],
+                    heat = simpson(integrand[0:imax] * self._E[popid][band][0:imax],
                         x=self.logE[popid][band][0:imax]) * log10
 
             else:
@@ -541,7 +541,7 @@ class GlobalVolume(object):
                     heat = np.trapz(integrand[imin:] * self._E[popid][band][imin:],
                         x=self.logE[popid][band][imin:]) * log10
                 else:
-                    heat = simps(integrand[imin:] * self._E[popid][band][imin:],
+                    heat = simpson(integrand[imin:] * self._E[popid][band][imin:],
                         x=self.logE[popid][band][imin:]) * log10
 
         # Re-normalize, get rid of per steradian units
@@ -696,7 +696,7 @@ class GlobalVolume(object):
                 ion = romb(integrand * self.E[popid][band],
                     dx=self.dlogE[popid][band])[0] * log10
             else:
-                ion = simps(integrand * self.E[popid][band],
+                ion = simpson(integrand * self.E[popid][band],
                     x=self.logE[popid][band]) * log10
 
         # Re-normalize
@@ -831,7 +831,7 @@ class GlobalVolume(object):
                 ion = romb(integrand * self.E[popid][band],
                     dx=self.dlogE[popid][band])[0] * log10
             else:
-                ion = simps(integrand * self.E[popid][band],
+                ion = simpson(integrand * self.E[popid][band],
                     x=self.logE[popid][band]) * log10
 
         # Re-normalize
@@ -927,7 +927,7 @@ class GlobalVolume(object):
                 e_ax = romb(integrand[0:imax] * self.E[0:imax],
                     dx=self.dlogE[0:imax])[0] * log10
             else:
-                e_ax = simps(integrand[0:imax] * self._E[popid][band][0:imax],
+                e_ax = simpson(integrand[0:imax] * self._E[popid][band][0:imax],
                     x=self.logE[popid][band][0:imax]) * log10
         else:
             imin = np.argmin(np.abs(self._E[popid][band] - pop.pf['pop_Emin']))
@@ -939,7 +939,7 @@ class GlobalVolume(object):
                 e_ax = np.trapz(integrand[imin:] * self._E[popid][band][imin:],
                     x=self.logE[popid][band][imin:]) * log10
             else:
-                e_ax = simps(integrand[imin:] * self._E[popid][band][imin:],
+                e_ax = simpson(integrand[imin:] * self._E[popid][band][imin:],
                     x=self.logE[popid][band][imin:]) * log10
 
         # Re-normalize. This is essentially a photon emissivity modulo 4 pi ster

--- a/ares/data/leitherer1999.py
+++ b/ares/data/leitherer1999.py
@@ -12,7 +12,6 @@ import re, os
 import numpy as np
 from ares.data import ARES
 from ares.physics import Cosmology
-from scipy.integrate import cumtrapz
 from scipy.interpolate import interp1d, RectBivariateSpline
 from ares.physics.Constants import h_p, c, erg_per_ev, g_per_msun, s_per_yr, \
     s_per_myr, m_H

--- a/ares/physics/DustEmission.py
+++ b/ares/physics/DustEmission.py
@@ -12,7 +12,7 @@ for each galaxy in a GalaxyEnsemble object based on Imara et al. (2018).
 """
 
 import numpy as np
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from ares.physics.Constants import c, h, k_B, g_per_msun, cm_per_kpc, Lsun
 
 # T_dust parameters
@@ -376,8 +376,8 @@ class DustEmission(object):
             tmp_cmb = 8 * np.pi * h / c**2 * cmb_kappa_nu * (cmb_freqs[None, :, None])**3 \
                 / (np.exp(h * cmb_freqs[None,:,None] / k_B / T_cmb[:,None,:]) - 1)
 
-            tmp_power = simps(tmp_stellar, self.frequencies, axis = 1)
-            tmp_power += simps(tmp_cmb, cmb_freqs, axis = 1)
+            tmp_power = simpson(tmp_stellar, self.frequencies, axis = 1)
+            tmp_power += simpson(tmp_cmb, cmb_freqs, axis = 1)
 
             if self.pf.get('pop_dust_experimental'):
                 print("power =", tmp_power)
@@ -519,7 +519,7 @@ class DustEmission(object):
                 fmax = c / (8 * 1e-4)
                 fmin = c / (1000 * 1e-4)
                 freqs, luminosities = self.dust_sed(fmin, fmax, 1000)
-                luminosities = simps(luminosities[:,:,index], freqs, axis = 1)
+                luminosities = simpson(luminosities[:,:,index], freqs, axis = 1)
 
         # is not cached, we calculate everything for the given z and wave
         else:
@@ -557,7 +557,7 @@ class DustEmission(object):
                 kappa_nu = 0.1 * (nu / 1e12)**2
                 luminosities = 8 * np.pi * h / c**2 * nu[None,:]**3 * kappa_nu[None,:] \
                     / (np.exp(h * nu[None,:] / k_B / T_dust[:,None]) - 1) * (M_dust[:,None] * g_per_msun)
-                luminosities = simps(luminosities, nu, axis = 1)
+                luminosities = simpson(luminosities, nu, axis = 1)
 
 
         if idnum is not None:

--- a/ares/physics/ExcursionSet.py
+++ b/ares/physics/ExcursionSet.py
@@ -15,7 +15,7 @@ from .Constants import rho_cgs
 from .Cosmology import Cosmology
 from ..util.Math import central_difference
 from ..util.ParameterFile import ParameterFile
-from scipy.integrate import simps, quad
+from scipy.integrate import quad
 from scipy.interpolate import interp1d
 from scipy.misc import derivative
 

--- a/ares/physics/HaloMassFunction.py
+++ b/ares/physics/HaloMassFunction.py
@@ -20,7 +20,7 @@ from functools import cached_property
 import numpy as np
 from scipy.misc import derivative
 from scipy.optimize import fsolve
-from scipy.integrate import cumtrapz, simps
+from scipy.integrate import cumulative_trapezoid, simpson
 from scipy.interpolate import (
     UnivariateSpline,
     RectBivariateSpline,
@@ -423,14 +423,14 @@ class HaloMassFunction(object):
                 mf_func = InterpolatedUnivariateSpline(np.log(m), np.log(dndlnm), k=1)
                 mf = mf_func(m_upper)
 
-                int_upper_n = simps(np.exp(mf), dx=m_upper[2] - m_upper[1], even='first')
-                int_upper_m = simps(np.exp(m_upper + mf), dx=m_upper[2] - m_upper[1], even='first')
+                int_upper_n = simpson(np.exp(mf), dx=m_upper[2] - m_upper[1], even='first')
+                int_upper_m = simpson(np.exp(m_upper + mf), dx=m_upper[2] - m_upper[1], even='first')
             else:
                 int_upper_n = 0
                 int_upper_m = 0
 
-            ngtm_ = np.concatenate((cumtrapz(dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
-            mgtm_ = np.concatenate((cumtrapz(m[::-1] * dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
+            ngtm_ = np.concatenate((cumulative_trapezoid(dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
+            mgtm_ = np.concatenate((cumulative_trapezoid(m[::-1] * dndlnm[::-1], dx=np.log(m[1]) - np.log(m[0]))[::-1], np.zeros(1)))
 
             ngtm.append(ngtm_ + int_upper_n)
             mgtm.append(mgtm_ + int_upper_m)
@@ -573,7 +573,7 @@ class HaloMassFunction(object):
                     x=np.log(self.tab_M))
                 self.tab_ngtm[i,:] = (
                     ngtm_0
-                    - cumtrapz(
+                    - cumulative_trapezoid(
                         self.tab_dndm[i] * self.tab_M,
                         x=np.log(self.tab_M),
                         initial=0.0,
@@ -581,7 +581,7 @@ class HaloMassFunction(object):
                 )
                 self.tab_mgtm[i,:] = (
                     mgtm_0
-                    - cumtrapz(
+                    - cumulative_trapezoid(
                         self.tab_dndm[i] * self.tab_M**2,
                         x=np.log(self.tab_M),
                         initial=0.0,

--- a/ares/populations/GalaxyCohort.py
+++ b/ares/populations/GalaxyCohort.py
@@ -23,7 +23,7 @@ from scipy.misc import derivative
 from scipy.optimize import fsolve
 from functools import cached_property
 from ..util.Misc import numeric_types, get_band_edges
-from scipy.integrate import quad, simps, cumtrapz, ode
+from scipy.integrate import quad, simpson, cumulative_trapezoid, ode
 from .GalaxyAggregate import GalaxyAggregate
 from .Population import normalize_sed, complex_sfhs
 from ..util.Stats import bin_c2e, bin_e2c
@@ -566,7 +566,7 @@ class GalaxyCohort(GalaxyAggregate):
 
 
             _tot = np.trapz(integrand, x=np.log(self.halos.tab_M))
-            _cumtot = cumtrapz(integrand, x=np.log(self.halos.tab_M),
+            _cumtot = cumulative_trapezoid(integrand, x=np.log(self.halos.tab_M),
                 initial=0.0)
 
             _tmp = _tot - \
@@ -619,7 +619,7 @@ class GalaxyCohort(GalaxyAggregate):
                 * self.tab_focc[i] * N_per_Msun * fesc * ok[i]
 
             tot = np.trapz(integrand, x=np.log(self.halos.tab_M))
-            cumtot = cumtrapz(integrand, x=np.log(self.halos.tab_M),
+            cumtot = cumulative_trapezoid(integrand, x=np.log(self.halos.tab_M),
                 initial=0.0)
 
             tab[i] = tot - \
@@ -782,7 +782,7 @@ class GalaxyCohort(GalaxyAggregate):
             else:
                 dtdz = np.array([self.cosm.dtdz(z) / s_per_yr \
                     for z in self.halos.tab_z])
-                self._tab_smd = cumtrapz(self.tab_sfrd_total[-1::-1] * dtdz[-1::-1],
+                self._tab_smd = cumulative_trapezoid(self.tab_sfrd_total[-1::-1] * dtdz[-1::-1],
                     dx=np.abs(np.diff(self.halos.tab_z[-1::-1])), initial=0.)[-1::-1]
 
             #self._func_smd = interp1d(self.halos.tab_z, self._tab_smd,
@@ -852,10 +852,10 @@ class GalaxyCohort(GalaxyAggregate):
 
                     integ = self.halos.tab_dndlnm[i] * MAR
 
-                    p0 = simps(integ[j1-1:], x=np.log(self.halos.tab_M)[j1-1:])
-                    p1 = simps(integ[j1:], x=np.log(self.halos.tab_M)[j1:])
-                    p2 = simps(integ[j1+1:], x=np.log(self.halos.tab_M)[j1+1:])
-                    p3 = simps(integ[j1+2:], x=np.log(self.halos.tab_M)[j1+2:])
+                    p0 = simpson(integ[j1-1:], x=np.log(self.halos.tab_M)[j1-1:])
+                    p1 = simpson(integ[j1:], x=np.log(self.halos.tab_M)[j1:])
+                    p2 = simpson(integ[j1+1:], x=np.log(self.halos.tab_M)[j1+1:])
+                    p3 = simpson(integ[j1+2:], x=np.log(self.halos.tab_M)[j1+2:])
 
                     interp = interp1d(np.log(self.halos.tab_M)[j1-1:j1+3], [p0,p1,p2,p3],
                         kind=self.pf['pop_interp_MAR'])
@@ -1567,7 +1567,7 @@ class GalaxyCohort(GalaxyAggregate):
 
         # Cumulative surface density of galaxies *brighter than* Mobs
         # [and optionally brighter ]
-        cgal = cumtrapz(Ngal, x=mags, initial=Ngal[0])
+        cgal = cumulative_trapezoid(Ngal, x=mags, initial=Ngal[0])
 
         if maglim is not None:
             return np.interp(maglim, mags, cgal)
@@ -4231,7 +4231,7 @@ class GalaxyCohort(GalaxyAggregate):
             integrand = self.tab_sfr * self.halos.tab_dndlnm * self.tab_focc
 
             ##
-            # Use cumtrapz instead and interpolate onto Mmin, Mmax
+            # Use cumulative_trapezoid instead and interpolate onto Mmin, Mmax
             ##
             ct = 0
             self._tab_sfrd_total_ = np.zeros_like(self.halos.tab_z)
@@ -4247,7 +4247,7 @@ class GalaxyCohort(GalaxyAggregate):
 
                 if self.is_central_pop:
                     tot = np.trapz(integrand[i], x=np.log(self.halos.tab_M))
-                    cumtot = cumtrapz(integrand[i], x=np.log(self.halos.tab_M),
+                    cumtot = cumulative_trapezoid(integrand[i], x=np.log(self.halos.tab_M),
                         initial=0.0)
                 else:
                     fsurv = self.tab_fsurv[i,:]
@@ -4272,7 +4272,7 @@ class GalaxyCohort(GalaxyAggregate):
                     integ = self.tab_sfr[i,:] * dndlnm_sat
 
                     tot = np.trapz(integ, dx=self.halos.dlnm)
-                    cumtot = cumtrapz(integ, dx=self.halos.dlnm,
+                    cumtot = cumulative_trapezoid(integ, dx=self.halos.dlnm,
                         initial=0.0)
 
 

--- a/ares/populations/GalaxyEnsemble.py
+++ b/ares/populations/GalaxyEnsemble.py
@@ -27,7 +27,7 @@ from .Halo import HaloPopulation
 from ..physics import DustEmission
 from .GalaxyCohort import GalaxyCohort
 from scipy.interpolate import interp1d
-from scipy.integrate import quad, cumtrapz
+from scipy.integrate import quad, cumulative_trapezoid
 from ares.data import read as read_lit
 from ..obs.Photometry import get_filters_from_waves
 from ..util.Stats import bin_e2c, bin_c2e, bin_samples, quantify_scatter
@@ -1048,7 +1048,7 @@ class GalaxyEnsemble(HaloPopulation):
         fml = (1. - fmr)
 
         # Integrate (crudely) mass accretion rates
-        #_Mint = cumtrapz(_MAR[:,:], dx=dt, axis=1)
+        #_Mint = cumulative_trapezoid(_MAR[:,:], dx=dt, axis=1)
         #_MAR_c = 0.5 * (np.roll(MAR, -1, axis=1) + MAR)
         #_Mint = np.cumsum(_MAR_c[:,1:] * dt, axis=1)
 
@@ -3683,7 +3683,7 @@ class GalaxyEnsemble(HaloPopulation):
             # some corresponding magnitude
             assert Ngal[i,0] == 0, "Broaden binning range?"
             #ntot = np.trapz(Ngal[i,:], x=x)
-            nltm[i,:] = cumtrapz(Ngal[i,:], x=bins, initial=Ngal[i,0])
+            nltm[i,:] = cumulative_trapezoid(Ngal[i,:], x=bins, initial=Ngal[i,0])
 
         # Can just return *maximum* number of galaxies detected,
         # regardless of band. Equivalent to requiring only single-band

--- a/ares/realizations/LightCone.py
+++ b/ares/realizations/LightCone.py
@@ -17,7 +17,6 @@ import h5py
 import numpy as np
 from ..simulations import Simulation
 from ..util.Stats import bin_e2c, bin_c2e
-from scipy.integrate import cumtrapz, quad
 from ..util.ProgressBar import ProgressBar
 from ..util.Misc import numeric_types, get_hash
 from scipy.spatial.transform import Rotation

--- a/ares/realizations/LogNormal.py
+++ b/ares/realizations/LogNormal.py
@@ -14,7 +14,7 @@ import gc
 import numpy as np
 from ..util import ProgressBar
 from .LightCone import LightCone
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.interpolate import interp1d
 from ..util.Stats import bin_c2e, bin_e2c
 from ..physics.Constants import cm_per_mpc
@@ -175,7 +175,7 @@ class LogNormal(LightCone): # pragma: no cover
             m = self.sim.pops[0].halos.tab_M[ok==1]
             dndm = self.sim.pops[0].halos.tab_dndm[iz,ok==1]
 
-            nall = cumtrapz(dndm * m, x=np.log(m), initial=0.0)
+            nall = cumulative_trapezoid(dndm * m, x=np.log(m), initial=0.0)
             nbar = np.trapz(dndm * m, x=np.log(m)) \
                  - np.exp(np.interp(np.log(mmin), np.log(m), np.log(nall)))
 
@@ -225,7 +225,7 @@ class LogNormal(LightCone): # pragma: no cover
         m = self.sim.pops[0].halos.tab_M[ok==1]
         dndm = self.sim.pops[0].halos.tab_dndm[iz,ok==1]
 
-        nall = cumtrapz(dndm * m, x=np.log(m), initial=0.0)
+        nall = cumulative_trapezoid(dndm * m, x=np.log(m), initial=0.0)
         nbar = np.trapz(dndm * m, x=np.log(m)) \
              - np.exp(np.interp(np.log(mmin), np.log(m), np.log(nall)))
 
@@ -429,7 +429,7 @@ class LogNormal(LightCone): # pragma: no cover
         dndm = self.sim.pops[0].halos.tab_dndm[iz,ok==1]
 
         # Compute CDF
-        ngtm = cumtrapz(dndm[-1::-1] * m[-1::-1], x=-np.log(m[-1::-1]),
+        ngtm = cumulative_trapezoid(dndm[-1::-1] * m[-1::-1], x=-np.log(m[-1::-1]),
             initial=0)[-1::-1]
 
         ntot = np.trapz(dndm * m, x=np.log(m))

--- a/ares/realizations/NbodySim.py
+++ b/ares/realizations/NbodySim.py
@@ -14,7 +14,6 @@ import gc
 import numpy as np
 from ..util import ProgressBar
 from .LightCone import LightCone
-from scipy.integrate import cumtrapz
 from ..simulations import Simulation
 from scipy.interpolate import interp1d
 from ..util.Stats import bin_c2e, bin_e2c

--- a/ares/solvers/UniformBackground.py
+++ b/ares/solvers/UniformBackground.py
@@ -24,7 +24,7 @@ from ..util.Warnings import no_tau_table
 from ..physics import Hydrogen, Cosmology
 from ..populations.Composite import CompositePopulation
 from ..populations.GalaxyAggregate import GalaxyAggregate
-from scipy.integrate import quad, romberg, romb, trapz, simps, cumtrapz
+from scipy.integrate import quad
 from ..physics.Constants import ev_per_hz, erg_per_ev, c, E_LyA, E_LL, dnu, \
     h_p, cm_per_mpc
 from ..util.Misc import num_freq_bins, get_rte_grid, get_rte_bands, \

--- a/ares/sources/SynthesisModel.py
+++ b/ares/sources/SynthesisModel.py
@@ -14,7 +14,7 @@ from functools import cached_property
 import numbers
 import numpy as np
 from scipy.optimize import minimize
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 from ..core import SpectralSynthesis
 from ..data import ARES
@@ -752,7 +752,7 @@ class SynthesisModelBase(Source):
         if self.is_ssp:
             photons_per_b_t = photons_per_s_per_msun / self.cosm.b_per_msun
             if return_all_t:
-                phot_per_b = cumtrapz(photons_per_b_t, x=self.tab_t*s_per_myr,
+                phot_per_b = cumulative_trapezoid(photons_per_b_t, x=self.tab_t*s_per_myr,
                     initial=0.0)
             else:
                 phot_per_b = np.trapz(photons_per_b_t, x=self.tab_t*s_per_myr)

--- a/ares/sources/SynthesisModelSBS.py
+++ b/ares/sources/SynthesisModelSBS.py
@@ -16,7 +16,7 @@ from .Source import Source
 import matplotlib.pyplot as pl
 from functools import cached_property
 from ares.data import read as read_lit
-from scipy.integrate import quad, cumtrapz
+from scipy.integrate import quad, cumulative_trapezoid
 from ..util.Stats import bin_c2e, bin_e2c
 from ..util.ParameterFile import ParameterFile
 from ..physics.Constants import h_p, c, erg_per_ev, ev_per_hz, \
@@ -359,7 +359,7 @@ class SynthesisModelSBS(Source): # pragma: no cover
         return 1. - 10**np.interp(np.log10(m), np.log10(self.Ms), np.log10(self.tab_imf_cdf))
 
     def mgtm(self, m):
-        cdf_by_m = cumtrapz(self.tab_imf * self.Ms**2, x=np.log(self.Ms), initial=0.) \
+        cdf_by_m = cumulative_trapezoid(self.tab_imf * self.Ms**2, x=np.log(self.Ms), initial=0.) \
             / np.trapz(self.tab_imf * self.Ms**2, x=np.log(self.Ms))
 
         return 1. - np.interp(m, self.Ms, cdf_by_m)
@@ -450,7 +450,7 @@ class SynthesisModelSBS(Source): # pragma: no cover
                 self._tab_imf_cdf = np.concatenate((_tot0, _tot1, _tot2)) / _tot2[-1]
 
             else:
-                self._tab_imf_cdf = cumtrapz(self.tab_imf, x=self.Ms, initial=0.) \
+                self._tab_imf_cdf = cumulative_trapezoid(self.tab_imf, x=self.Ms, initial=0.) \
                     / np.trapz(self.tab_imf * self.Ms, x=np.log(self.Ms))
 
         return self._tab_imf_cdf
@@ -502,7 +502,7 @@ class SynthesisModelSBS(Source): # pragma: no cover
     def tab_dtd_cdf(self):
         if not hasattr(self, '_tab_dtd_cdf'):
             ok = self.Ms >= 8.
-            top = cumtrapz(self.tab_life[ok==1] * self.tab_imf[ok==1] \
+            top = cumulative_trapezoid(self.tab_life[ok==1] * self.tab_imf[ok==1] \
                 * self.Ms[ok==1], x=np.log(self.Ms[ok==1]), initial=0.0)
 
             bot = np.trapz(self.tab_life[ok==1] * self.tab_imf[ok==1] \

--- a/ares/util/SetDefaultParameterValues.py
+++ b/ares/util/SetDefaultParameterValues.py
@@ -1498,7 +1498,7 @@ def ControlParameters():
         "sed_prefix": None,
 
         "unsampled_integrator": 'quad',
-        "sampled_integrator": 'simps',
+        "sampled_integrator": 'simpson',
         "integrator_rtol": 1e-6,
         "integrator_atol": 1e-4,
         "integrator_divmax": 1e2,

--- a/input/halos/test_fcoll.py
+++ b/input/halos/test_fcoll.py
@@ -13,7 +13,7 @@ Description:
 import ares
 import numpy as np
 import matplotlib.pyplot as pl
-from scipy.integrate import simps
+from scipy.integrate import simpson
 
 pop = ares.populations.HaloPopulation(pop_sfr_model='fcoll', pop_Mmin=1e8,
     halo_mf_interp='linear')
@@ -38,7 +38,7 @@ for z in zarr:
     dndlnm = dndm * M
 
     #fcoll_mgtm2 = np.trapz(dndlnm, x=np.log(M)) / pop.halos.MF.mean_density0
-    fcoll_mgtm2 = simps(dndlnm[ok], x=np.log(M[ok])) / pop.halos.MF.mean_density0
+    fcoll_mgtm2 = simpson(dndlnm[ok], x=np.log(M[ok])) / pop.halos.MF.mean_density0
 
     print('{0!s} {1!s} {2!s}'.format(z, fcoll_mgtm1, fcoll_mgtm2))#, fcoll
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup_args = {
         "h5py",
         "numpy",
         "matplotlib",
-        "scipy",
+        "scipy>=1.6",
         "setuptools_scm",
     ],
     "extras_require": {


### PR DESCRIPTION
Several of the integration functions in SciPy have been renamed, but throughout ARES the old functions were still being imported. In particular, SciPy has renamed `simps` -> `simpson`, `trapz` -> `trapezoid`, and `cumtrapz` -> `cumulative_trapezoid`. As of [version 1.14](https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations), these are no longer issuing a `DeprecationWarning` and have been entirely removed, which leads to import errors when running in an environment with recent-ish versions of SciPy.

In addition to these changes, this PR adds a version requirement to SciPy (>=1.6), as that seems to be [the first version when the new names were added](https://docs.scipy.org/doc/scipy/release/1.6.0-notes.html#scipy-integrate-improvements). It sounds as though this is just a name change and the underlying functionality is the same as previous, though I have not tested this personally.

It looks like NumPy has made [a similar name change](https://numpy.org/doc/stable/reference/generated/numpy.trapezoid.html), though this would require NumPy version >=2. Because that seems like a more onerous requirement given how new it is, I have only changed the SciPy names (which have been around for a few years).